### PR TITLE
Add bug report, feature request and pull request templates for GitHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,35 @@
+---
+name: "Bug report \U0001F41B"
+about: Create a report to help us improve
+labels: bug
+
+---
+
+### Describe the Bug
+<!-- A clear and concise description of what the bug is. -->
+
+
+### Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected Behavior
+<!-- A clear and concise description of what you expected to happen. -->
+
+
+### Actual Behavior
+<!-- A clear and concise description of what actually happened. -->
+
+
+### Additional Information
+<!-- Add any other context (e.g. logs, screenshots, etc.) about the problem here. -->
+
+<details>
+  <summary>Traceback</summary>
+
+  ```
+  ```
+</details>

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,30 @@
+---
+name: "Feature request \U0001F4A1"
+about: Suggest an idea for this project
+labels: feature
+
+---
+
+### Motivation
+<!-- A clear and concise description of what the motivation for the new feature is, and what problem it is solving. -->
+
+
+### User Story
+<!-- A clear description of the User Stories that should be achieved by the new feature. The User Stories should follow this pattern: 
+As a [type of user] I want [goals or objectives] so that [values or benefits]. -->
+
+
+### Proposed Solution
+<!-- A clear and concise description of the feature you would like to add, and how it solves the motivating problem. -->
+
+
+### Alternatives
+<!-- A clear and concise description of any alternative solutions or features you've considered, and why you're proposed solution is better. -->
+
+
+### Additional Context
+<!-- Add any other background information about the feature request here. -->
+
+
+### Screenshots
+<!-- If the feature requires an implementation of templates, please add at least one screenshot of the requested template from our Figma design file -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+### Short description
+<!-- Describe this PR in one or two sentences. -->
+
+
+### Proposed changes
+<!-- Describe this PR in more detail. -->
+
+- 
+- 
+
+
+### Side effects
+<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
+
+- 
+- 
+
+
+### Resolved issues
+<!-- List all issues which should be closed when this PR is merged. -->
+
+Fixes: #


### PR DESCRIPTION
This PR adds GitHub templates for bug reports, feature requests and pull requests.

- Create a .github folder
- Create three md files with the template

The templates are the same as we use in Lunes CMS and Integreat CMS. I like them as they are, that's why I didn't change them. However since we're leaning stronger towards TDD it might be interesting to hear what you think about it

Fixes #13 