### PR TITLE
Enable pylint for more files

### DIFF
--- a/integreat_compass/integreat-compass-cli
+++ b/integreat_compass/integreat-compass-cli
@@ -2,7 +2,6 @@
 """Django's command-line utility for administrative tasks."""
 import os
 import sys
-from django.core.management.commands.runserver import Command as runserver
 
 
 def main():
@@ -10,6 +9,7 @@ def main():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "integreat_compass.core.settings")
 
     try:
+        # pylint: disable=import-outside-toplevel
         from django.core.management import execute_from_command_line
     except ImportError as exc:
         raise ImportError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "build",
     "pylint",
     "pylint-django",
+    "pylint-per-file-ignores",
     "pytest-circleci-parallelized",
     "pytest-cov",
     "pytest-django",
@@ -75,6 +76,7 @@ dev-pinned = [
     "pprintpp==0.4.0",
     "pylint==2.17.2",
     "pylint-django==2.5.3",
+    "pylint-per-file-ignores==1.2.0",
     "pylint-plugin-utils==0.7",
     "pyproject_hooks==1.0.0",
     "pytest==7.3.1",
@@ -110,6 +112,7 @@ skip-magic-trailing-comma = true
 jobs = 0
 load-plugins = [
     "pylint_django",
+    "pylint_per_file_ignores",
     "pylint.extensions.code_style",
     "pylint.extensions.comparetozero",
     "pylint.extensions.comparison_placement",
@@ -157,3 +160,6 @@ enable = [
 
 [tool.pylint.reports]
 output-format = "colorized"
+
+[tool.pylint-per-file-ignores]
+"/tests/"="unused-argument,missing-function-docstring"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,6 @@ ROOT = "ROOT"
 ANONYMOUS = "ANONYMOUS"
 
 
-# pylint: disable=unused-argument
 @pytest.fixture(scope="session")
 def load_test_data(django_db_setup, django_db_blocker):
     """

--- a/tools/pylint.sh
+++ b/tools/pylint.sh
@@ -10,5 +10,6 @@ require_installed
 
 # Run pylint
 echo "Starting code linting with pylint..." | print_info
-pylint .
+# Explicitly include cli which does not have a .py ending
+pylint . integreat_compass/integreat-compass-cli
 echo "✔ Linting finished" | print_success


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Enable pylint for more files.
Unfortunately, pylint is not able to disable specific warnings for entire directories (see https://github.com/pylint-dev/pylint/issues/618), so I added the plugin https://github.com/christopherpickering/pylint-per-file-ignores

### Proposed changes
<!-- Describe this PR in more detail. -->

- Enable pylint for tests directory (but disable `unused-argument` and `missing-function-docstring`)
- Enable pylint for `integreat-compass-cli`
