### PR TITLE
Add versioning tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,12 +16,12 @@ repos:
       - id: no-commit-to-branch
         args: [--branch, main, --branch, develop]
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.8.0.4
+    rev: v0.9.0.2
     hooks:
       - id: shellcheck
         args: [--external-sources]
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.27.0
+    rev: v8.39.0
     hooks:
       - id: eslint
         files: \.[jt]sx?$
@@ -40,7 +40,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.23.1
+    rev: v1.25.0
     hooks:
       - id: djlint-django
   - repo: https://github.com/pycqa/isort

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -39,7 +39,7 @@ copyright = "Tür an Tür – Digitalfabrik gGmbH"
 #: The project author
 author = "Tür an Tür - Digitalfabrik GmbH"
 #: The full version, including alpha/beta/rc tags
-release = "2023.4.0"
+release = "2023.3.0"
 #: GitHub username
 github_username = "digitalfabrik"
 #: GitHub repository name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dynamic = ["version"]
 dev = [
     "black",
     "build",
+    "bumpver",
     "djlint",
     "isort",
     "pylint",
@@ -54,28 +55,29 @@ dev = [
 ]
 pinned = [
     "asgiref==3.6.0",
-    "Django==4.2",
-    "psycopg==3.1.8",
-    "psycopg-binary==3.1.8",
+    "Django==4.2.1",
+    "psycopg==3.1.9",
+    "psycopg-binary==3.1.9",
     "sqlparse==0.4.4",
     "typing_extensions==4.5.0",
 ]
 dev-pinned = [
     "alabaster==0.7.13",
-    "astroid==2.15.3",
+    "astroid==2.15.4",
     "Babel==2.12.1",
     "black==23.3.0",
     "build==0.10.0",
+    "bumpver==2022.1120",
     "certifi==2022.12.7",
     "charset-normalizer==3.1.0",
     "click==8.1.3",
     "colorama==0.4.6",
-    "coverage==7.2.3",
+    "coverage==7.2.5",
     "cssbeautifier==1.14.7",
     "dill==0.3.6",
-    "djlint==1.23.1",
-    "EditorConfig==0.12.3",
+    "djlint==1.25.0",
     "docutils==0.18.1",
+    "EditorConfig==0.12.3",
     "exceptiongroup==1.1.1",
     "execnet==1.9.0",
     "html-tag-names==0.1.2",
@@ -86,19 +88,21 @@ dev-pinned = [
     "importlib-metadata==6.6.0",
     "iniconfig==2.0.0",
     "isort==5.12.0",
-    "jsbeautifier==1.14.7",
     "Jinja2==3.1.2",
+    "jsbeautifier==1.14.7",
     "lazy-object-proxy==1.9.0",
+    "lexid==2021.1006",
     "MarkupSafe==2.1.2",
     "mccabe==0.7.0",
     "mypy-extensions==1.0.0",
     "packaging==23.1",
+    "pathlib2==2.3.7.post1",
     "pathspec==0.11.1",
-    "platformdirs==3.2.0",
+    "platformdirs==3.5.0",
     "pluggy==1.0.0",
     "pprintpp==0.4.0",
     "Pygments==2.15.1",
-    "pylint==2.17.2",
+    "pylint==2.17.3",
     "pylint-django==2.5.3",
     "pylint-per-file-ignores==1.2.0",
     "pylint-plugin-utils==0.7",
@@ -111,14 +115,11 @@ dev-pinned = [
     "pytest-testmon==2.0.6",
     "pytest-xdist==3.2.1",
     "PyYAML==6.0",
-    "regex==2023.3.23",
+    "regex==2023.5.4",
+    "requests==2.29.0",
     "six==1.16.0",
-    "tomli==2.0.1",
-    "tomlkit==0.11.7",
-    "tqdm==4.65.0",
-    "requests==2.28.2",
     "snowballstemmer==2.2.0",
-    "Sphinx==6.2.0",
+    "Sphinx==6.2.1",
     "sphinxcontrib-applehelp==1.0.4",
     "sphinxcontrib-devhelp==1.0.2",
     "sphinxcontrib-django==2.3",
@@ -129,8 +130,10 @@ dev-pinned = [
     "sphinxcontrib-serializinghtml==1.1.5",
     "sphinx-last-updated-by-git==0.3.4",
     "sphinx-rtd-theme==1.2.0",
+    "toml==0.10.2",
     "tomli==2.0.1",
-    "tomlkit==0.11.7",
+    "tomlkit==0.11.8",
+    "tqdm==4.65.0",
     "urllib3==1.26.15",
     "wrapt==1.15.0",
     "zipp==3.15.0",
@@ -149,6 +152,27 @@ version = { attr = "integreat_compass.__version__" }
 
 [tool.setuptools.packages.find]
 include = ["integreat_compass*"]
+
+[tool.bumpver]
+current_version = "2023.3.0"
+version_pattern = "YYYY.MM.INC0[-TAG]"
+commit_message = """
+Bump version to {new_version}
+
+[skip ci]
+"""
+
+
+[tool.bumpver.file_patterns]
+"pyproject.toml" = [
+    'current_version = "{version}"',
+]
+"integreat_compass/__init__.py" = [
+    '__version__ = "{version}"',
+]
+"docs/src/conf.py" = [
+    'release = "{version}"',
+]
 
 [tool.black]
 skip-magic-trailing-comma = true


### PR DESCRIPTION
### Short description
This PR introduced CalVer as versioning scheme, and adds bumpver as versioning tools, that automatically bumps the version


### Proposed changes

- Add bumpver
- Define CalVer as versioning scheme in setup for bumpver
- Set current version to 2023.0.0


### Side effects

I read about versioning schemes for the first time today, but still was trying to make an informed decision. Here is my reasoning for why I chose to go with a calendar based versioning scheme:
I think one could make a case for logical schemes, like MAJOR.MINOR.PATCH, but I see two issues with it: 1. AFAIK it's still quite unclear how this project will evolve, and 2. I don't really see any cases where we would bump the major version. Therefore I came to the conclusion that a more flexible scheme, such as CalVer, fits our needs better. Please feel free to comment or suggest different schemes. 

### Resolved issues

Fixes: #10 
