### PR TITLE
Create new OfferVersion when details were changed

### DIFF
--- a/integreat_compass/cms/forms/offers/offer_version_form.py
+++ b/integreat_compass/cms/forms/offers/offer_version_form.py
@@ -90,6 +90,7 @@ class OfferVersionForm(CustomModelForm):
         """
         This method extends the default ``save()``-method of the base :class:`~django.forms.ModelForm`
         to manage the ManyToMany relation with :class:`~integrat_compass.cms.models.offers.document.Document`.
+        and to ensure a new instance is created instead of updating the old one.
 
         :param commit: Whether or not the changes should be written to the database
         :type commit: bool
@@ -97,8 +98,20 @@ class OfferVersionForm(CustomModelForm):
         :return: The saved region object
         :rtype: ~integreat_cms.cms.models.offers.offer_version.OfferVersion
         """
-        offer_version = super().save(commit=commit)
-        for document in self.cleaned_data["documents_to_remove"]:
-            document.offer_versions.remove(offer_version)
+        original_instance = None
+        if self.instance.pk:
+            original_instance = OfferVersion.objects.get(pk=self.instance.pk)
+            for field in self.Meta.fields:
+                if getattr(self.instance, field) != getattr(original_instance, field):
+                    self.instance.pk = None
+                    break
 
+        offer_version = super().save(commit=commit)
+
+        to_remove = [offer_version] + [original_instance] if original_instance else []
+        for document in self.cleaned_data["documents_to_remove"]:
+            for instance in to_remove:
+                document.offer_versions.remove(instance)
+
+        offer_version = super().save(commit=commit)
         return offer_version

--- a/integreat_compass/cms/views/offers/offer_form_view.py
+++ b/integreat_compass/cms/views/offers/offer_form_view.py
@@ -33,7 +33,7 @@ class OfferFormView(TemplateView):
     def _get_forms(offer_id, **kwargs):
         if offer_id:
             offer = Offer.objects.get(id=offer_id)
-            offer_version = offer.versions.first()
+            offer_version = list(offer.versions.select_related())[-1]
             offer_contact = offer.offer_contact
             offer_location = offer.location
             offer_organization = offer.organization


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Previously we just updated the version, which we specifically did not want to do

### Proposed changes
<!-- Describe this PR in more detail. -->

- check if any offer version fields were changed by the user; if so, create a new instance
- actually get the latest offer version instance in the offer form view


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #64
