### PR TITLE
Fix over-precise coordinates preventing form submission

### DIFF
--- a/integreat_compass/cms/migrations/0001_initial.py
+++ b/integreat_compass/cms/migrations/0001_initial.py
@@ -208,13 +208,13 @@ class Migration(migrations.Migration):
                 (
                     "lat",
                     models.DecimalField(
-                        decimal_places=6, max_digits=9, verbose_name="latitude"
+                        decimal_places=7, max_digits=10, verbose_name="latitude"
                     ),
                 ),
                 (
                     "long",
                     models.DecimalField(
-                        decimal_places=6, max_digits=9, verbose_name="longitude"
+                        decimal_places=7, max_digits=10, verbose_name="longitude"
                     ),
                 ),
             ],

--- a/integreat_compass/cms/models/organizations/location.py
+++ b/integreat_compass/cms/models/organizations/location.py
@@ -16,10 +16,10 @@ class Location(AbstractBaseModel):
         help_text=_("Physical location where the offer takes place"),
     )
     lat = models.DecimalField(
-        max_digits=9, decimal_places=6, verbose_name=_("latitude")
+        max_digits=10, decimal_places=7, verbose_name=_("latitude")
     )
     long = models.DecimalField(
-        max_digits=9, decimal_places=6, verbose_name=_("longitude")
+        max_digits=10, decimal_places=7, verbose_name=_("longitude")
     )
 
     def __str__(self):

--- a/integreat_compass/static/src/js/map.ts
+++ b/integreat_compass/static/src/js/map.ts
@@ -16,17 +16,18 @@ const getCoordinates = () => {
     return null;
 };
 
-export const updateField = (fieldName: string, value: number) => {
+export const updateField = (fieldName: string, value: string) => {
     const field = document.getElementById(`id_location-${fieldName}`) as HTMLInputElement;
-    if (value && field.value !== value.toString()) {
-        field.value = value.toString();
+    if (value && field.value !== value) {
+        field.value = value;
     }
 };
 
 const updateCoordinates = (marker: Marker) => {
     const lngLat = marker.getLngLat();
-    updateField("long", lngLat.lng);
-    updateField("lat", lngLat.lat);
+    const maxCoordinatePrecision = 7;
+    updateField("long", lngLat.lng.toFixed(maxCoordinatePrecision));
+    updateField("lat", lngLat.lat.toFixed(maxCoordinatePrecision));
 };
 
 window.addEventListener("load", () => {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Small fix for a bug I did not notice before: Previously, when clicking on the map, the coordinates received from the marker had larger post-comma precision than the coordinate field on the location model allowed for, and the form would not Save. The user would also not be notified, since the lat/long fields are hidden.

### Proposed changes
<!-- Describe this PR in more detail. -->

- increase precision in the `Location` model
- fix the coordinates received from the marker to the same number of decimal places
