### PR TITLE
Add custom logging formatters

### DIFF
--- a/integreat_compass/core/logging_formatter.py
+++ b/integreat_compass/core/logging_formatter.py
@@ -1,0 +1,64 @@
+import logging
+
+
+class ColorFormatter(logging.Formatter):
+    """
+    Logging Formatter to add colors
+    """
+
+    COLORS = {
+        logging.DEBUG: 36,  # cyan
+        logging.INFO: 34,  # blue
+        logging.WARNING: 33,  # yellow
+        logging.ERROR: 31,  # red
+        logging.CRITICAL: 31,  # red
+    }
+
+    def format(self, record):
+        """
+        Format the specified record as colored text (see :meth:`python:logging.Formatter.format`).
+
+        :param record: The log record
+        :type record: ~logging.LogRecord
+
+        :return: The formatted logging message
+        :rtype: str
+        """
+        # Define color escape sequence
+        color = f"\x1b[0;{self.COLORS.get(record.levelno)}m"
+        # Make level name bold
+        fmt = self._fmt.replace("{levelname}", "\x1b[1m{levelname}" + color)
+        # Make entire line colored
+        # pylint: disable=protected-access
+        self._style._fmt = color + fmt + "\x1b[0m"
+        return super().format(record)
+
+
+class RequestFormatter(logging.Formatter):
+    """
+    Logging Formatter to log the GET parameters of a failed HTTP request
+    """
+
+    def format(self, record):
+        """
+        Format the specified record including the request if possible (see :meth:`python:logging.Formatter.format`).
+
+        :param record: The log record
+        :type record: ~logging.LogRecord
+
+        :return: The formatted logging message
+        :rtype: str
+        """
+        message = super().format(record)
+        if record.name == "django.request":
+            message = message.replace(
+                "django.request - ", f"django.request - {record.status_code} "
+            )
+            if query := record.request.META["QUERY_STRING"]:
+                if "\n" in message:
+                    # If the string is multi-line (e.g. because the traceback follows), only append to first line
+                    message = message.replace("\n", f"?{query}\n", 1)
+                else:
+                    # If the string consists of one single line, just append it to the end
+                    message += f"?{query}"
+        return message

--- a/integreat_compass/core/settings.py
+++ b/integreat_compass/core/settings.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 from django.utils.translation import gettext_lazy as _
 
+from .logging_formatter import ColorFormatter, RequestFormatter
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -231,3 +233,72 @@ NEW_OFFER_GREMIUM_SIZE = int(
 CHANGED_OFFER_GREMIUM_SIZE = int(
     os.environ.get("INTEGREAT_COMPASS_CHANGED_OFFER_GREMIUM_SIZE", 4)
 )
+
+###########
+# LOGGING #
+###########
+
+#: The log level for integreat-cms django apps
+LOG_LEVEL = os.environ.get("INTEGREAT_COMPASS_LOG_LEVEL", "DEBUG" if DEBUG else "INFO")
+
+#: The file path of the logfile. Needs to be writable by the application.
+LOGFILE = os.environ.get(
+    "INTEGREAT_COMPASS_LOGFILE", os.path.join(BASE_DIR, "integreat-compass.log")
+)
+
+#: Logging configuration dictionary (see :setting:`django:LOGGING`)
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "console-colored": {
+            "()": ColorFormatter,
+            "format": "{asctime} {levelname} {name} - {message}",
+            "datefmt": "%b %d %H:%M:%S",
+            "style": "{",
+        },
+        "management-command": {
+            "()": ColorFormatter,
+            "format": "{message}",
+            "style": "{",
+        },
+        "logfile": {
+            "()": RequestFormatter,
+            "format": "{asctime} {levelname:7} {name} - {message}",
+            "datefmt": "%b %d %H:%M:%S",
+            "style": "{",
+        },
+    },
+    "filters": {
+        "require_debug_true": {"()": "django.utils.log.RequireDebugTrue"},
+        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"},
+    },
+    "handlers": {
+        "console-colored": {
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+            "formatter": "console-colored",
+        },
+        "management-command": {
+            "filters": ["require_debug_true"],
+            "class": "logging.StreamHandler",
+            "formatter": "management-command",
+        },
+        "logfile": {
+            "class": "logging.FileHandler",
+            "filename": LOGFILE,
+            "formatter": "logfile",
+        },
+    },
+    "loggers": {
+        "integreat_compass": {
+            "handlers": ["console-colored", "logfile"],
+            "level": LOG_LEVEL,
+        },
+        "integreat_compass.core.management.commands": {
+            "handlers": ["management-command", "logfile"],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
+    },
+}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add custom logging formatters for colored output and better-formatted requests

### Proposed changes
<!-- Describe this PR in more detail. -->

- copy over custom logging formatter classes from Integreat
- copy relevant parts of django logger config from Integreat


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- more verbose logs (not necessarily bad)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #54
