### PR TITLE
Offer Application usability tweaks

### DIFF
--- a/integreat_compass/cms/migrations/0001_initial.py
+++ b/integreat_compass/cms/migrations/0001_initial.py
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
                 (
                     "name",
                     models.CharField(
-                        help_text="Name of the point-of-contact person",
+                        help_text="Name of the responsible contact person",
                         max_length=255,
                         verbose_name="name",
                     ),
@@ -119,7 +119,7 @@ class Migration(migrations.Migration):
                 (
                     "email",
                     models.EmailField(
-                        help_text="Email address of the point-of-contact person",
+                        help_text="Email address of the responsible contact person",
                         max_length=254,
                         verbose_name="email",
                     ),
@@ -128,7 +128,7 @@ class Migration(migrations.Migration):
                     "phone",
                     models.CharField(
                         blank=True,
-                        help_text="Phone numbner of the point-of-contact person",
+                        help_text="Phone numbner of the responsible contact person",
                         max_length=20,
                         verbose_name="phone number",
                     ),
@@ -332,6 +332,7 @@ class Migration(migrations.Migration):
                 (
                     "language",
                     models.ForeignKey(
+                        default=integreat_compass.cms.models.offers.offer_version.get_default_language,
                         help_text="The language being taught in this offer",
                         on_delete=django.db.models.deletion.CASCADE,
                         to="cms.language",

--- a/integreat_compass/cms/models/offers/offer_version.py
+++ b/integreat_compass/cms/models/offers/offer_version.py
@@ -9,6 +9,20 @@ from ..abstract_base_model import AbstractBaseModel
 from .language import Language
 
 
+def get_default_language():
+    """
+    Helper function to get or create the default offer language.
+
+    :return: pk of the default offer language
+    :rtype: int
+    """
+    language, _ = Language.objects.get_or_create(
+        native_name=settings.DEFAULT_OFFER_LANGUAGE["native_name"],
+        defaults=settings.DEFAULT_OFFER_LANGUAGE,
+    )
+    return language.pk
+
+
 class OfferVersion(AbstractBaseModel):
     """
     Data model representing a Language.
@@ -32,6 +46,7 @@ class OfferVersion(AbstractBaseModel):
     )
     language = models.ForeignKey(
         Language,
+        default=get_default_language,
         on_delete=models.CASCADE,
         verbose_name=_("Language"),
         help_text=_("The language being taught in this offer"),

--- a/integreat_compass/cms/models/organizations/contact.py
+++ b/integreat_compass/cms/models/organizations/contact.py
@@ -14,17 +14,17 @@ class Contact(AbstractBaseModel):
     name = models.CharField(
         max_length=255,
         verbose_name=_("name"),
-        help_text=_("Name of the point-of-contact person"),
+        help_text=_("Name of the responsible contact person"),
     )
     email = models.EmailField(
         verbose_name=_("email"),
-        help_text=_("Email address of the point-of-contact person"),
+        help_text=_("Email address of the responsible contact person"),
     )
     phone = models.CharField(
         max_length=20,
         blank=True,
         verbose_name=_("phone number"),
-        help_text=_("Phone numbner of the point-of-contact person"),
+        help_text=_("Phone numbner of the responsible contact person"),
     )
 
     def __str__(self):

--- a/integreat_compass/core/settings.py
+++ b/integreat_compass/core/settings.py
@@ -168,6 +168,10 @@ AVAILABLE_LANGUAGES = {"de": _("German"), "en": _("English")}
 #: The default UI languages
 DEFAULT_LANGUAGES = ["de", "en"]
 
+#: The default offer language
+DEFAULT_OFFER_LANGUAGE = {"native_name": "Deutsch", "english_name": "German"}
+
+
 #: The list of languages which are available in the UI
 #: (see :setting:`django:LANGUAGES` and :doc:`django:topics/i18n/index`)
 LANGUAGES = [

--- a/integreat_compass/locale/de/LC_MESSAGES/django.po
+++ b/integreat_compass/locale/de/LC_MESSAGES/django.po
@@ -284,24 +284,24 @@ msgid "name"
 msgstr "Name"
 
 #: cms/models/organizations/contact.py
-msgid "Name of the point-of-contact person"
-msgstr "Name der Kontaktperson"
+msgid "Name of the responsible contact person"
+msgstr "Name der Ansprechperson"
 
 #: cms/models/organizations/contact.py cms/models/users/user.py
 msgid "email"
 msgstr "E-Mail"
 
 #: cms/models/organizations/contact.py
-msgid "Email address of the point-of-contact person"
-msgstr "E-Mail-Adresse der Kontaktperson"
+msgid "Email address of the responsible contact person"
+msgstr "E-Mail-Adresse der Ansprechperson"
 
 #: cms/models/organizations/contact.py
 msgid "phone number"
 msgstr "Telefonnummer"
 
 #: cms/models/organizations/contact.py
-msgid "Phone numbner of the point-of-contact person"
-msgstr "Telefonnummer der Kontaktperson"
+msgid "Phone numbner of the responsible contact person"
+msgstr "Telefonnummer der Ansprechperson"
 
 #: cms/models/organizations/contact.py
 msgid "offer contact"

--- a/integreat_compass/static/src/css/style.scss
+++ b/integreat_compass/static/src/css/style.scss
@@ -38,7 +38,7 @@ h2 {
 [multiple],
 textarea,
 select {
-    @apply w-full rounded text-xl text-gray-800 border-gray-500 shadow-md;
+    @apply scroll-mt-40 w-full rounded text-xl text-gray-800 border-gray-500 shadow-md;
     &:focus {
         @apply bg-white border-blue-500 ring-blue-500 #{!important};
     }

--- a/integreat_compass/static/src/index.ts
+++ b/integreat_compass/static/src/index.ts
@@ -1,4 +1,5 @@
 import "./css/style.scss";
+import "./js/field-validation";
 import "./js/map";
 import { createIconsAt } from "./js/utils/create-icons";
 

--- a/integreat_compass/static/src/js/field-validation.ts
+++ b/integreat_compass/static/src/js/field-validation.ts
@@ -1,0 +1,10 @@
+window.addEventListener("load", () => {
+    const urlField = document.getElementById("id_organization-web_address") as HTMLInputElement;
+    if (urlField) {
+        urlField.addEventListener("blur", () => {
+            if (!urlField.value.match(/^https?:/)) {
+                urlField.value = `http://${urlField.value}`;
+            }
+        });
+    }
+});


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR addresses some usability issues with the offer application form Martin pointed out.

### Proposed changes
<!-- Describe this PR in more detail. -->

- adjusted the help texts for Contact fields to be clearer (esp. in English)
- pre-select German as the default offer language
- add a scroll-offset to input elements, so when client-side validation fails and the browser jumps to a field, it isn't covered by our menu bar
- auto-fill `http://` in front of the web address if the user did not specify a protocol (client-side validation fails without it) 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

/ 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /
