### PR TITLE
Fix bug preventing submission of online-only offers

### DIFF
--- a/integreat_compass/cms/forms/offers/location_form.py
+++ b/integreat_compass/cms/forms/offers/location_form.py
@@ -1,7 +1,9 @@
 import logging
 
 from django import forms
+from django.utils.translation import gettext_lazy as _
 
+from ...constants import offer_mode_types
 from ...models import Location
 from ..custom_model_form import CustomModelForm
 
@@ -24,3 +26,37 @@ class LocationForm(CustomModelForm):
         model = Location
         fields = ["address", "lat", "long"]
         widgets = {"address": forms.TextInput()}
+
+    def __init__(self, *args, **kwargs):
+        r"""
+        Initialize offer version form
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+        """
+        super().__init__(*args, **kwargs)
+        self.data = kwargs.get("data", [])
+
+    def clean(self):
+        """
+        Validate form fields which depend on each other, see :meth:`django.forms.Form.clean`:
+        If no address is given for a non-online offer, add a :class:`~django.core.exceptions.ValidationError`.
+
+        :return: The cleaned form data
+        :rtype: dict
+        """
+        cleaned_data = super().clean()
+        if self.data["offer-mode_type"] == offer_mode_types.ONLINE:
+            cleaned_data["address"] = None
+            cleaned_data["lat"] = None
+            cleaned_data["long"] = None
+            return cleaned_data
+
+        if any(not cleaned_data.get(field) for field in ["address", "lat", "long"]):
+            self.add_error(
+                "address", forms.ValidationError(_("A valid address is required."))
+            )
+        return cleaned_data

--- a/integreat_compass/cms/forms/offers/offer_version_form.py
+++ b/integreat_compass/cms/forms/offers/offer_version_form.py
@@ -76,7 +76,6 @@ class OfferVersionForm(CustomModelForm):
     def clean(self):
         """
         Validate form fields which depend on each other, see :meth:`django.forms.Form.clean`:
-        If the file type is invalid, add a :class:`~django.core.exceptions.ValidationError`.
 
         :return: The cleaned form data
         :rtype: dict

--- a/integreat_compass/cms/migrations/0001_initial.py
+++ b/integreat_compass/cms/migrations/0001_initial.py
@@ -127,7 +127,7 @@ class Migration(migrations.Migration):
                     "phone",
                     models.CharField(
                         blank=True,
-                        help_text="Phone numbner of the responsible contact person",
+                        help_text="Phone number of the responsible contact person",
                         max_length=20,
                         verbose_name="phone number",
                     ),
@@ -200,20 +200,30 @@ class Migration(migrations.Migration):
                 (
                     "address",
                     models.TextField(
+                        blank=True,
                         help_text="Physical location where the offer takes place",
+                        null=True,
                         verbose_name="address",
                     ),
                 ),
                 (
                     "lat",
                     models.DecimalField(
-                        decimal_places=7, max_digits=10, verbose_name="latitude"
+                        blank=True,
+                        decimal_places=7,
+                        max_digits=10,
+                        null=True,
+                        verbose_name="latitude",
                     ),
                 ),
                 (
                     "long",
                     models.DecimalField(
-                        decimal_places=7, max_digits=10, verbose_name="longitude"
+                        blank=True,
+                        decimal_places=7,
+                        max_digits=10,
+                        null=True,
+                        verbose_name="longitude",
                     ),
                 ),
             ],

--- a/integreat_compass/cms/models/organizations/contact.py
+++ b/integreat_compass/cms/models/organizations/contact.py
@@ -24,7 +24,7 @@ class Contact(AbstractBaseModel):
         max_length=20,
         blank=True,
         verbose_name=_("phone number"),
-        help_text=_("Phone numbner of the responsible contact person"),
+        help_text=_("Phone number of the responsible contact person"),
     )
 
     def __str__(self):

--- a/integreat_compass/cms/models/organizations/location.py
+++ b/integreat_compass/cms/models/organizations/location.py
@@ -10,16 +10,24 @@ class Location(AbstractBaseModel):
     """
 
     address = models.TextField(
-        blank=False,
-        null=False,
+        blank=True,
+        null=True,
         verbose_name=_("address"),
         help_text=_("Physical location where the offer takes place"),
     )
     lat = models.DecimalField(
-        max_digits=10, decimal_places=7, verbose_name=_("latitude")
+        blank=True,
+        null=True,
+        max_digits=10,
+        decimal_places=7,
+        verbose_name=_("latitude"),
     )
     long = models.DecimalField(
-        max_digits=10, decimal_places=7, verbose_name=_("longitude")
+        blank=True,
+        null=True,
+        max_digits=10,
+        decimal_places=7,
+        verbose_name=_("longitude"),
     )
 
     def __str__(self):

--- a/integreat_compass/cms/templates/offers/offer_form.html
+++ b/integreat_compass/cms/templates/offers/offer_form.html
@@ -107,10 +107,7 @@
                     <div id="location-form-wrapper">
                         {% with location_form.address as field %}
                             <div>
-                                <label for="{{ field.id_for_label }}"
-                                       {% if field.field.required %}class="field-required"{% endif %}>
-                                    {{ field.label }}
-                                </label>
+                                <label for="{{ field.id_for_label }}" class="field-required">{{ field.label }}&nbsp;</label>
                                 {% render_field field %}
                                 <div class="help-text">{{ field.help_text }}</div>
                             </div>

--- a/integreat_compass/locale/de/LC_MESSAGES/django.po
+++ b/integreat_compass/locale/de/LC_MESSAGES/django.po
@@ -94,6 +94,10 @@ msgstr "Das Dateiformat {} ist nicht erlaubt."
 msgid "Allowed file types"
 msgstr "Erlaubte Dateiformate"
 
+#: cms/forms/offers/location_form.py
+msgid "A valid address is required."
+msgstr "Eine gültige Adresse ist erforderlich."
+
 #: cms/forms/offers/offer_version_form.py
 msgid "Yes"
 msgstr "Ja"
@@ -312,7 +316,7 @@ msgid "phone number"
 msgstr "Telefonnummer"
 
 #: cms/models/organizations/contact.py
-msgid "Phone numbner of the responsible contact person"
+msgid "Phone number of the responsible contact person"
 msgstr "Telefonnummer der Ansprechperson"
 
 #: cms/models/organizations/contact.py

--- a/integreat_compass/static/src/js/map.ts
+++ b/integreat_compass/static/src/js/map.ts
@@ -114,7 +114,14 @@ window.addEventListener("load", () => {
             locationFormWrapper.classList.add("hidden");
         } else {
             locationFormWrapper.classList.remove("hidden");
+            searchBar.focus();
+            window.scrollTo({ top: document.body.scrollHeight, behavior: "smooth" });
         }
+
+        const [lat, long] = getCoordinateInputFields();
+        lat.required = !onlineCheckbox.checked;
+        long.required = !onlineCheckbox.checked;
+        searchBar.required = !onlineCheckbox.checked;
     });
     modeSwitch.dispatchEvent(new Event("click"));
 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix bug preventing submission of online-only offers

### Proposed changes
<!-- Describe this PR in more detail. -->

- address, lat, long fields are no longer required
- in the LocationForm `clean` method, check if the offer mode is ONLINE; if not, and one of the mentioned fields is missing, show a message to the user

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none I am aware of


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #72
