### PR TITLE
Add offer provider registration form

### DIFF
--- a/integreat_compass/cms/forms/__init__.py
+++ b/integreat_compass/cms/forms/__init__.py
@@ -8,3 +8,4 @@ from .offers.location_form import LocationForm
 from .offers.offer_form import OfferForm
 from .offers.offer_version_form import OfferVersionForm
 from .offers.organization_form import OrganizationForm
+from .registration_form import RegistrationForm

--- a/integreat_compass/cms/forms/registration_form.py
+++ b/integreat_compass/cms/forms/registration_form.py
@@ -1,0 +1,111 @@
+import logging
+
+from django import forms
+from django.contrib.auth.password_validation import validate_password
+from django.utils.translation import gettext as _
+
+from ..constants import group_names
+from ..models import User
+from .custom_model_form import CustomModelForm
+
+logger = logging.getLogger(__name__)
+
+
+class RegistrationForm(CustomModelForm):
+    """
+    Form for user self-registration as offer providers
+    """
+
+    password = forms.CharField(
+        widget=forms.PasswordInput(), validators=[validate_password]
+    )
+    password_confirm = forms.CharField(
+        label=_("Confirm password"), widget=forms.PasswordInput()
+    )
+
+    class Meta:
+        """
+        This class contains additional meta configuration of the form class, see the :class:`django.forms.ModelForm`
+        for more information.
+        """
+
+        model = User
+        fields = ["email", "display_name"]
+
+    def clean(self):
+        """
+        Validate form fields which depend on each other, see :meth:`django.forms.Form.clean`:
+        If passwords do not match, add a :class:`~django.core.exceptions.ValidationError`.
+
+        :return: The cleaned form data
+        :rtype: dict
+        """
+        cleaned_data = super().clean()
+        if cleaned_data.get("password") != cleaned_data.get("password_confirm"):
+            self.add_error(
+                "password_confirm", forms.ValidationError(_("Passwords do not match."))
+            )
+        return cleaned_data
+
+    def clean_email(self):
+        """
+        Ensure the email does not exist yet, see :ref:`overriding-modelform-clean-method`:
+        If the email is already registered, add a :class:`~django.core.exceptions.ValidationError`.
+
+        :return: The password
+        :rtype: str
+        """
+
+        email = self.cleaned_data["email"]
+        if User.objects.filter(email=email).first():
+            self.add_error(
+                "email",
+                forms.ValidationError(
+                    _(
+                        'An account for the email "{}" does already exist. Did you mean to log in?'
+                    ).format(email)
+                ),
+            )
+        return email
+
+    def clean_display_name(self):
+        """
+        Ensure the display_name does not exist yet, see :ref:`overriding-modelform-clean-method`:
+        If the display_name is already taken, add a :class:`~django.core.exceptions.ValidationError`.
+
+        :return: The display_name
+        :rtype: str
+        """
+
+        display_name = self.cleaned_data["display_name"]
+        if User.objects.filter(display_name=display_name).first():
+            self.add_error(
+                "display_name",
+                forms.ValidationError(
+                    _('The display name "{}" is already taken.').format(display_name)
+                ),
+            )
+        return display_name
+
+    def save(self, commit=True):
+        """
+        This method extends the default ``save()``-method of the base :class:`~django.forms.ModelForm`
+        to create a new non-active user with role Offer Provider.
+
+        :param commit: Whether or not the changes should be written to the database
+        :type commit: bool
+
+        :return: The saved region object
+        :rtype: ~integreat_cms.cms.models.offers.offer_version.OfferVersion
+        """
+        cleaned_data = self.cleaned_data
+        new_user = User.objects.create_user(
+            email=cleaned_data["email"],
+            display_name=cleaned_data["display_name"],
+            password=cleaned_data["password"],
+            group=group_names.OFFER_PROVIDER,
+            is_active=False,
+        )
+
+        logger.debug("Created new offer provider %s", self.cleaned_data["email"])
+        return new_user

--- a/integreat_compass/cms/models/users/user.py
+++ b/integreat_compass/cms/models/users/user.py
@@ -18,7 +18,13 @@ class CustomUserManager(BaseUserManager):
     """
 
     def create_user(
-        self, email, display_name, password=None, group=None, **extra_fields
+        self,
+        email,
+        display_name,
+        password=None,
+        group=None,
+        is_active=False,
+        **extra_fields,
     ):
         """
         Create a new user and ensure they are added to the correct group (if any)
@@ -38,17 +44,24 @@ class CustomUserManager(BaseUserManager):
         :param extra_fields: additional fields
         :type extra_fields: dict
 
+        :param is_active: Whether this user should be active
+        :type is_active: bool
+
         :return: the newly created user
         :rtype: ~integreat_compass.cms.models.users.user.User
         """
         email = self.normalize_email(email)
-        user = self.model(email=email, display_name=display_name, **extra_fields)
-
-        if group and group in group_names.CHOICES:
-            user.groups.add(Group.objects.get(name=group))
+        user = self.model(
+            email=email, display_name=display_name, is_active=is_active, **extra_fields
+        )
 
         user.set_password(password)
         user.save(using=self._db)
+
+        if group and group in dict(group_names.CHOICES):
+            user.groups.add(Group.objects.get(name=group))
+            user.save()
+
         return user
 
     def create_superuser(self, email, display_name, password=None, **extra_fields):

--- a/integreat_compass/cms/templates/_base.html
+++ b/integreat_compass/cms/templates/_base.html
@@ -27,11 +27,15 @@
                 <div class="ml-auto mr-4 flex-align-right font-bold hover:text-gray-900">
                     <a href="{% url 'cms:public:login' %}">{% translate "Login" %}</a>
                 </div>
+                <div class="ml-4 mr-4 flex-align-right font-bold hover:text-gray-900">
+                    <a href="{% url 'cms:public:register' %}"
+                       class="text-primary hover:text-gray-900">{% translate "Register" %}</a>
+                </div>
             {% endif %}
         </div>
     </div>
     <div class="container mx-auto px-4 py-6 mt-28">
-        {% if messages %}
+        {% if messages and not messages_suppressed %}
             <div id="messages" class="mb-8">
                 {% for msg in messages %}
                     {% if msg.level_tag == 'info' %}

--- a/integreat_compass/cms/templates/authentication/registration.html
+++ b/integreat_compass/cms/templates/authentication/registration.html
@@ -1,0 +1,20 @@
+{% extends "_base.html" %}
+{% load i18n %}
+{% load widget_tweaks %}
+{% block title %}
+    {% translate "Registration" %}
+{% endblock title %}
+{% block content %}
+    <div class="flex justify-center items-center">
+        <div class="w-1/3 bg-white shadow p-8">
+            <h2>{% translate "Register as an Offer Provider" %}</h2>
+            <form action="{% url 'cms:public:register' %}" method="post">
+                {% csrf_token %}
+                {{ form }}
+                <div class="mt-6 flex items-center justify-between">
+                    <button class="btn" type="submit">{% translate "Sign Up" %}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+{% endblock content %}

--- a/integreat_compass/cms/templates/emails/_base_email.html
+++ b/integreat_compass/cms/templates/emails/_base_email.html
@@ -1,0 +1,38 @@
+{% load i18n %}
+<!DOCTYPE html>
+{% get_current_language as LANGUAGE_CODE %}
+{# djlint:off H006,H016,H030,H031 #}
+<html lang="{{ LANGUAGE_CODE }}">
+    <head>
+        <meta charset="utf-8" />
+        <style>
+        #content {
+            font-family: sans-serif;
+            text-align: justify;
+            background-color: #f1f5f9;
+            padding: 1rem;
+            border-radius: 1rem;
+            line-height: 1.5;
+        }
+
+        a {
+            color: #0074CC;
+        }
+
+        a:hover {
+            color: #1F9EFF;
+        }
+
+        #logo {
+            padding-top: 1rem;
+        }
+        </style>
+    </head>
+    <body>
+        <div id="content">
+            {% block content %}
+            {% endblock content %}
+        </div>
+    </body>
+</html>
+{# djlint:on #}

--- a/integreat_compass/cms/templates/emails/activation_email.html
+++ b/integreat_compass/cms/templates/emails/activation_email.html
@@ -1,0 +1,22 @@
+{% extends "emails/_base_email.html" %}
+{% load i18n %}
+{% block content %}
+    {% translate "Welcome" %} {{ user.display_name }},
+    <br />
+    <br />
+    {% blocktranslate trimmed %}
+        You are receiving this e-mail because you created an account with Integreat Compass.
+    {% endblocktranslate %}
+    <br />
+    {% translate "Please use the link below to activate your account." %}
+    <br />
+    <br />
+    <a href="{{ base_url }}{% url 'cms:public:activate_account' uidb64=uid token=token %}">
+        {{ base_url }}{% url 'cms:public:activate_account' uidb64=uid token=token %}
+    </a>
+    <br />
+    <br />
+    {% translate "If using the link above does not work, please copy the URL and paste it into the address bar of your
+    browser." %}
+    <br />
+{% endblock content %}

--- a/integreat_compass/cms/templates/emails/activation_email.txt
+++ b/integreat_compass/cms/templates/emails/activation_email.txt
@@ -1,0 +1,9 @@
+{% load i18n %}
+
+{% translate "Welcome" %} {{ user.display_name }},
+{% blocktranslate trimmed %}
+    You are receiving this e-mail because you created an account with Integreat Compass.
+{% endblocktranslate %}
+{% translate "Please use the link below to activate your account." %}
+{{ base_url }}{% url 'cms:public:activate_account' uidb64=uid token=token %}
+{% translate "If using the link above does not work, please copy the URL and paste it into the address bar of your browser." %}

--- a/integreat_compass/cms/urls/public.py
+++ b/integreat_compass/cms/urls/public.py
@@ -1,7 +1,7 @@
 from django.contrib.auth import views as auth_views
 from django.urls import include, path
 
-from ..views import index
+from ..views import authentication, index
 
 urlpatterns = [
     path("", index.IndexView.as_view(), name="index"),
@@ -17,6 +17,16 @@ urlpatterns = [
                     name="login",
                 ),
                 path("logout/", auth_views.LogoutView.as_view(), name="logout"),
+                path(
+                    "register/",
+                    authentication.RegistrationView.as_view(),
+                    name="register",
+                ),
+                path(
+                    "activate-account/<uidb64>/<token>/",
+                    authentication.AccountActivationView.as_view(),
+                    name="activate_account",
+                ),
             ]
         ),
     ),

--- a/integreat_compass/cms/utils/account_activation_token_generator.py
+++ b/integreat_compass/cms/utils/account_activation_token_generator.py
@@ -1,0 +1,18 @@
+"""
+This module contains helpers for the account activation process
+(also see :class:`~integreat_compass.cms.views.authentication.account_activation_view.AccountActivationView`).
+"""
+from django.contrib.auth.tokens import PasswordResetTokenGenerator
+
+
+class AccountActivationTokenGenerator(PasswordResetTokenGenerator):
+    """
+    This token generator is identical to the default password reset token generator of :mod:`django.contrib.auth` with
+    the exception of the used HMAC salt.
+    This means password reset tokens are no longer accepted for the account activation and vice versa.
+    """
+
+    key_salt = "integreat_compass.cms.utils.account_activation_token_generator.AccountActivationTokenGenerator"
+
+
+account_activation_token_generator = AccountActivationTokenGenerator()

--- a/integreat_compass/cms/utils/email_utils.py
+++ b/integreat_compass/cms/utils/email_utils.py
@@ -1,0 +1,83 @@
+import logging
+
+from django.conf import settings
+from django.core.mail import BadHeaderError, EmailMultiAlternatives
+from django.template.loader import render_to_string
+from django.utils.encoding import force_bytes
+from django.utils.http import urlsafe_base64_encode
+from django.utils.translation import gettext as _
+
+from .account_activation_token_generator import account_activation_token_generator
+
+logger = logging.getLogger(__name__)
+
+
+def send_mail(
+    subject, email_template_name, html_email_template_name, context, recipient
+):
+    """
+    Sends welcome email to user with new account.
+
+    Making use of  :class:`~django.core.mail.EmailMultiAlternatives`
+    to send a multipart email with plain text and html version.
+
+    :param subject: The subject of the email
+    :type subject: str
+
+    :param email_template_name: The template to be used to render the text email
+    :type email_template_name: str
+
+    :param html_email_template_name: The template to be used to render the HTML email
+    :type html_email_template_name: str
+
+    :param subject: The subject of the email
+    :type subject: str
+
+    :param context: The template context variables
+    :type context: dict
+
+    :param recipient: The email address of the recipient
+    :type recipient: str
+    """
+    context.update({"base_url": settings.BASE_URL})
+
+    body = render_to_string(email_template_name, context)
+    email = EmailMultiAlternatives(subject=subject, body=body, to=[recipient])
+    email.mixed_subtype = "related"
+
+    html_message = render_to_string(html_email_template_name, context)
+    email.attach_alternative(html_message, "text/html")
+
+    email.send()
+
+
+def send_activation_mail(user):
+    """
+    Send an activation email to a newly registered user
+
+    :param user: the newly registered user
+    :type user: ~integreat_compass.cms.models.user.User
+    """
+    context = {"user": user}
+    subject = "Integreat Compass | Confirm your account"
+
+    token = account_activation_token_generator.make_token(user)
+    uid = urlsafe_base64_encode(force_bytes(user.pk))
+
+    subject += _("Activate your account")
+    debug_mail_type = _("activation mail")
+    context.update({"uid": uid, "token": token})
+
+    try:
+        send_mail(
+            subject,
+            "emails/activation_email.txt",
+            "emails/activation_email.html",
+            context,
+            user.email,
+        )
+        logger.debug(
+            "Sent a %r with an activation link to %r", debug_mail_type, user.email
+        )
+    except BadHeaderError as e:
+        logger.exception(e)

--- a/integreat_compass/cms/views/authentication/__init__.py
+++ b/integreat_compass/cms/views/authentication/__init__.py
@@ -1,0 +1,5 @@
+"""
+This package contains views related to registration, login, logout and password reset
+"""
+from .account_activation_view import AccountActivationView
+from .registration_view import RegistrationView

--- a/integreat_compass/cms/views/authentication/account_activation_view.py
+++ b/integreat_compass/cms/views/authentication/account_activation_view.py
@@ -1,0 +1,73 @@
+import logging
+
+from django.contrib import messages
+from django.contrib.auth import views as auth_views
+from django.shortcuts import redirect
+from django.utils.http import urlsafe_base64_decode
+from django.utils.translation import gettext as _
+
+from ...models import User
+from ...utils.account_activation_token_generator import (
+    account_activation_token_generator,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class AccountActivationView(auth_views.PasswordResetConfirmView):
+    """
+    View to set a new password and activate and account.
+    """
+
+    token_generator = account_activation_token_generator
+
+    def dispatch(self, *args, **kwargs):
+        r"""
+        The view part of the view. Handles all HTTP methods equally.
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :return: The rendered template response or a redirection to the login page
+        :rtype: ~django.template.response.TemplateResponse or ~django.http.HttpResponseRedirect
+        """
+        if self.request.user.is_authenticated:
+            messages.success(self.request, _("You are already logged in."))
+            return redirect("cms:public:index")
+
+        user = User.objects.filter(
+            pk=int(urlsafe_base64_decode(kwargs.get("uidb64")))
+        ).first()
+        if not user:
+            messages.error(
+                self.request,
+                _("The account you are trying to activate does not exist."),
+            )
+            return redirect("cms:public:index")
+
+        if self.token_generator.check_token(user, kwargs.get("token")):
+            messages.success(
+                self.request, _("Your account has been successfully activated.")
+            )
+            user.is_active = True
+            user.save()
+            logger.info("Account activation for user %r was successful", user)
+            return redirect("cms:public:login")
+
+        messages.error(
+            self.request,
+            " ".join(
+                [
+                    _("This account activation link is invalid."),
+                    _("It may have already been used."),
+                    _(
+                        "Please contact an administrator to request a new link to activate your account."
+                    ),
+                ]
+            ),
+        )
+        logger.debug("An invalid account activation link was used.")
+        return redirect("cms:public:login")

--- a/integreat_compass/cms/views/authentication/registration_view.py
+++ b/integreat_compass/cms/views/authentication/registration_view.py
@@ -1,0 +1,39 @@
+import logging
+
+from django.contrib import messages
+from django.urls import reverse_lazy
+from django.utils.translation import gettext as _
+from django.views.generic.edit import CreateView
+
+from ...forms import RegistrationForm
+from ...utils.email_utils import send_activation_mail
+
+logger = logging.getLogger(__name__)
+
+
+class RegistrationView(CreateView):
+    """
+    View allowing new users to sign up as offer providers
+    """
+
+    template_name = "authentication/registration.html"
+    form_class = RegistrationForm
+    success_url = reverse_lazy("cms:public:login")
+
+    def form_valid(self, form):
+        r"""
+        Overwrite the form_valid method to additionally send a confirmation email
+
+        :param form: The user-submitted form
+        :type form: ~integreat_compass.cms.forms.registration_form.RegistrationForm
+        """
+        response = super().form_valid(form)
+        messages.success(
+            self.request,
+            _(
+                'A confirmation email has been sent to "{}". Please use the link in the email to activate your account.'
+            ).format(self.object.email),
+        )
+
+        send_activation_mail(self.object)
+        return response

--- a/integreat_compass/core/settings.py
+++ b/integreat_compass/core/settings.py
@@ -183,7 +183,7 @@ LANGUAGES = [
         (
             language.strip()
             for language in os.environ.get(
-                "INTEGREAT_CMS_LANGUAGES", "\n".join(DEFAULT_LANGUAGES)
+                "INTEGREAT_COMPASS_LANGUAGES", "\n".join(DEFAULT_LANGUAGES)
             ).splitlines()
         ),
     )
@@ -309,3 +309,57 @@ LOGGING = {
         },
     },
 }
+
+##########
+# EMAILS #
+##########
+
+#: The backend to use for sending emails (see :setting:`django:EMAIL_BACKEND` and :doc:`django:topics/email`)
+EMAIL_BACKEND = (
+    "django.core.mail.backends.console.EmailBackend"
+    if DEBUG
+    else "django.core.mail.backends.smtp.EmailBackend"
+)
+
+#: Default email address to use for various automated correspondence from the site manager(s)
+#: (see :setting:`django:DEFAULT_FROM_EMAIL`)
+DEFAULT_FROM_EMAIL = os.environ.get(
+    "INTEGREAT_COMPASS_SERVER_EMAIL", "noreply@example.com"
+)
+
+#: The email address that error messages come from, such as those sent to :attr:`~integreat_compass.core.settings.ADMINS`.
+#: (see :setting:`django:SERVER_EMAIL`)
+SERVER_EMAIL = os.environ.get("INTEGREAT_COMPASS_SERVER_EMAIL", "noreply@example.com")
+
+#: A list of all the people who get code error notifications. When :attr:`~integreat_compass.core.settings.DEBUG` is ``False``,
+#: Django emails these people the details of exceptions raised in the request/response cycle.
+ADMINS = [("Integreat Compass Helpdesk", "tech@integreat-compass.de")]
+
+#: The host to use for sending email (see :setting:`django:EMAIL_HOST`)
+EMAIL_HOST = os.environ.get("INTEGREAT_COMPASS_EMAIL_HOST", "localhost")
+
+#: Password to use for the SMTP server defined in :attr:`~integreat_compass.core.settings.EMAIL_HOST`
+#: (see :setting:`django:EMAIL_HOST_PASSWORD`). If empty, Django won’t attempt authentication.
+EMAIL_HOST_PASSWORD = os.environ.get("INTEGREAT_COMPASS_EMAIL_HOST_PASSWORD")
+
+#: Username to use for the SMTP server defined in :attr:`~integreat_compass.core.settings.EMAIL_HOST`
+#: (see :setting:`django:EMAIL_HOST_USER`). If empty, Django won’t attempt authentication.
+EMAIL_HOST_USER = os.environ.get("INTEGREAT_COMPASS_EMAIL_HOST_USER", SERVER_EMAIL)
+
+#: Port to use for the SMTP server defined in :attr:`~integreat_compass.core.settings.EMAIL_HOST`
+#: (see :setting:`django:EMAIL_PORT`)
+EMAIL_PORT = int(os.environ.get("INTEGREAT_COMPASS_EMAIL_PORT", 587))
+
+#: Whether to use a TLS (secure) connection when talking to the SMTP server.
+#: This will use Opportunistic TLS (STARTTLS command after starting a plain text connection).
+#: (see :setting:`django:EMAIL_USE_TLS`)
+EMAIL_USE_TLS = bool(
+    strtobool(os.environ.get("INTEGREAT_COMPASS_EMAIL_USE_TLS", "True"))
+)
+
+#: Whether to use an implicit TLS (secure) connection when talking to the SMTP server.
+#: In most email documentation this type of TLS connection is referred to as SSL. It is generally used on port 465.
+#: (see :setting:`django:EMAIL_USE_SSL`)
+EMAIL_USE_SSL = bool(
+    strtobool(os.environ.get("INTEGREAT_COMPASS_EMAIL_USE_SSL", "False"))
+)

--- a/integreat_compass/locale/de/LC_MESSAGES/django.po
+++ b/integreat_compass/locale/de/LC_MESSAGES/django.po
@@ -106,6 +106,25 @@ msgstr "Ja"
 msgid "No"
 msgstr "Nein"
 
+#: cms/forms/registration_form.py
+msgid "Confirm password"
+msgstr "Passwort bestätigen"
+
+#: cms/forms/registration_form.py
+msgid "Passwords do not match."
+msgstr "Die Passwörter stimmen nicht überein."
+
+#: cms/forms/registration_form.py
+msgid ""
+"An account for the email \"{}\" does already exist. Did you mean to log in?"
+msgstr ""
+"Ein Account mit der Email \"{}\" existiert bereits. Wollten Sie sich "
+"stattdessen anmelden?"
+
+#: cms/forms/registration_form.py
+msgid "The display name \"{}\" is already taken."
+msgstr "Der Anzeigename \"{}\" ist bereits vergeben."
+
 #: cms/models/interactions/comment.py cms/models/interactions/report.py
 #: cms/models/interactions/vote.py
 msgid "comment"
@@ -428,6 +447,10 @@ msgstr "Abmelden"
 msgid "Login"
 msgstr "Login"
 
+#: cms/templates/_base.html
+msgid "Register"
+msgstr "Registrieren"
+
 #: cms/templates/authentication/login.html
 msgid "The username or the password is incorrect."
 msgstr "Der Benutzername oder das Passwort sind inkorrekt."
@@ -447,6 +470,45 @@ msgstr "Passwort eingeben"
 #: cms/templates/authentication/login.html
 msgid "Sign In"
 msgstr "Einloggen"
+
+#: cms/templates/authentication/registration.html
+msgid "Registration"
+msgstr "Registrierung"
+
+#: cms/templates/authentication/registration.html
+msgid "Register as an Offer Provider"
+msgstr "Als Maßnahmen-Anbieter registrieren"
+
+#: cms/templates/authentication/registration.html
+msgid "Sign Up"
+msgstr "Registrieren"
+
+#: cms/templates/emails/activation_email.html
+#: cms/templates/emails/activation_email.txt
+msgid "Welcome"
+msgstr "Willkommen"
+
+#: cms/templates/emails/activation_email.html
+#: cms/templates/emails/activation_email.txt
+msgid ""
+"You are receiving this e-mail because you created an account with Integreat "
+"Compass."
+msgstr ""
+"Sie erhalten diese Email da Sie einen Account im Integreat Compass angelegt "
+"haben."
+
+#: cms/templates/emails/activation_email.html
+#: cms/templates/emails/activation_email.txt
+msgid "Please use the link below to activate your account."
+msgstr "Nutzen Sie den folgenden Link um Ihren Account zu aktivieren."
+
+#: cms/templates/emails/activation_email.txt
+msgid ""
+"If using the link above does not work, please copy the URL and paste "
+"it into the address bar of your browser."
+msgstr ""
+"Falls obiger Link nicht funktioniert, kopieren Sie die URL bitte und fügen "
+"Sie sie in der Adresszeile Ihres Browsers ein."
 
 #: cms/templates/index.html
 msgid "Home"
@@ -505,6 +567,49 @@ msgstr "Angaben der Organisation"
 msgid "Submit offer application"
 msgstr "Maßnahmenbewerbung absenden"
 
+#: cms/utils/email_utils.py
+msgid "Activate your account"
+msgstr "Aktivieren Sie Ihren Account"
+
+#: cms/utils/email_utils.py
+msgid "activation mail"
+msgstr "Aktivierungs-Mail"
+
+#: cms/views/authentication/account_activation_view.py
+msgid "You are already logged in."
+msgstr "Sie sind bereits eingeloggt."
+
+#: cms/views/authentication/account_activation_view.py
+msgid "The account you are trying to activate does not exist."
+msgstr "Der Account den Sie versuchen zu aktivieren existiert nicht."
+
+#: cms/views/authentication/account_activation_view.py
+msgid "Your account has been successfully activated."
+msgstr "Ihr Account wurde erfolgreich freigeschalten."
+
+#: cms/views/authentication/account_activation_view.py
+msgid "This account activation link is invalid."
+msgstr "Der Accountaktivierungslink ist ungültig."
+
+#: cms/views/authentication/account_activation_view.py
+msgid "It may have already been used."
+msgstr "Möglicherweise wurde er bereits verwendet."
+
+#: cms/views/authentication/account_activation_view.py
+msgid ""
+"Please contact an administrator to request a new link to activate your "
+"account."
+msgstr ""
+"Bitte kontaktieren Sie einen Administrator um einen neuen Link anzufordern."
+
+#: cms/views/authentication/registration_view.py
+msgid ""
+"A confirmation email has been sent to \"{}\". Please use the link in the "
+"email to activate your account."
+msgstr ""
+"Wir haben eine Bestätigungsmail an \"{}\" gesandt. Bitten nutzen Sie "
+"den Link in der E-Mail, um Ihren Account zu aktivieren."
+
 #: cms/views/offers/offer_form_view.py
 msgid ""
 "Application for the offer \"{}\" has successfully been submitted and will be "
@@ -532,9 +637,6 @@ msgstr "Englisch"
 
 #~ msgid "for-profit"
 #~ msgstr "For-Profit"
-
-#~ msgid "registered association"
-#~ msgstr "eingetragener Verein"
 
 #~ msgid "cost"
 #~ msgstr "Kosten"

--- a/integreat_compass/static/src/css/style.scss
+++ b/integreat_compass/static/src/css/style.scss
@@ -135,6 +135,10 @@ label:not([for]) {
     }
 }
 
+.errorlist {
+    @apply bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 mb-5;
+}
+
 /***********
  * BUTTONS *
  ***********/


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add a form (and needed logic) for users to register themselves as an offer provider


### Proposed changes
<!-- Describe this PR in more detail. -->

- add the form
- send an activation link
- activate account on clicking that link


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none I am aware of


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #52
