### PR TITLE
Read config file in command line interface

### DIFF
--- a/integreat_compass/integreat-compass-cli
+++ b/integreat_compass/integreat-compass-cli
@@ -1,22 +1,50 @@
-#!/usr/bin/env python
-"""Django's command-line utility for administrative tasks."""
+#!/usr/bin/env python3
+""" Django's command-line utility for administrative tasks. """
+import configparser
 import os
 import sys
 
 
-def main():
-    """Run administrative tasks."""
+def read_config():
+    """
+    Reads and parses the corresponding configurations.
+    """
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "integreat_compass.core.settings")
+
+    # Read config from config file
+    config = configparser.ConfigParser(interpolation=None)
+    config.read("/etc/integreat-compass.ini")
+    for section in config.sections():
+        for KEY, VALUE in config.items(section):
+            os.environ.setdefault(f"INTEGREAT_COMPASS_{KEY.upper()}", VALUE)
+
+
+def main():
+    """
+    Application entry point
+
+    :raises ImportError: If the Django framework is not installed or not in the path, an import error is risen.
+
+    """
+    read_config()
 
     try:
         # pylint: disable=import-outside-toplevel
         from django.core.management import execute_from_command_line
-    except ImportError as exc:
-        raise ImportError(
-            "Couldn't import Django. Are you sure it's installed and "
-            "available on your PYTHONPATH environment variable? Did you "
-            "forget to activate a virtual environment?"
-        ) from exc
+    except ImportError:
+        # The above import may fail for some other reason. Ensure that the
+        # issue is really that Django is missing to avoid masking other
+        # exceptions on Python 2.
+        try:
+            # pylint: disable=import-outside-toplevel,unused-import
+            import django
+        except ImportError as e:
+            raise ImportError(
+                "Couldn't import Django. Are you sure it's installed and "
+                "available on your PYTHONPATH environment variable? Did you "
+                "forget to activate a virtual environment?"
+            ) from e
+        raise
     execute_from_command_line(sys.argv)
 
 


### PR DESCRIPTION
### Short description
Just another small thing I came across: we want to read the `/etc/integreat-compass.ini` file when executing `integreat-compass-cli`.


### Proposed changes
- Modify integreat-compass-cli to read the config file.


### Side effects
- Should work w/o problems. We're using this for the integreat-cms for a long time now.


### Resolved issues
- N/A
