### PR TITLE
Manage users via CRUD in production

### DIFF
--- a/integreat_compass/cms/admin.py
+++ b/integreat_compass/cms/admin.py
@@ -4,6 +4,7 @@ Debug lists and forms for all models
 from django.apps import apps
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth import get_user_model
 
 if settings.DEBUG:
     admin.site.register(apps.get_model("auth", "Permission"))
@@ -15,3 +16,5 @@ if settings.DEBUG:
         admin.site.register(model)
     for model in apps.get_app_config("sessions").get_models():
         admin.site.register(model)
+else:
+    admin.site.register(get_user_model())


### PR DESCRIPTION
### Short description
In #42 we decided to manage users via CRUD for the MVP. This PR always registers the user and permissions model in the CRUD back end.


### Proposed changes
- Register user model when DEBUG is False. 


### Side effects
- N/A


### Resolved issues
Fixes: #42 
