### PR TITLE
Fix display of dates for all offers and my offers view

### DIFF
--- a/integreat_compass/cms/templates/index.html
+++ b/integreat_compass/cms/templates/index.html
@@ -114,7 +114,7 @@
                                             <span class="text-white bg-primary rounded-2xl px-3 py-1 leading-8">{{ tag }}</span>
                                         {% endfor %}
                                     </div>
-                                    <p class="text-gray-400">{{ offer.public_version.offer_version_date }}</p>
+                                    <p class="text-gray-400">{% translate "Created at:" %} {{ offer.public_version.created_at|date:"d. M Y" }}</p>
                                 </div>
                             </div>
                             {% include "overlay/offer-detail-overlay.html" %}

--- a/integreat_compass/cms/templates/interactions/vote_form.html
+++ b/integreat_compass/cms/templates/interactions/vote_form.html
@@ -23,7 +23,7 @@
                                 <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
                             {% endfor %}
                         </div>
-                        <p class="text-gray-700">{% translate "created at" %}: {{ offer_version.created_at }}</p>
+                        <p class="text-gray-700">{% translate "Created at:" %} {{ offer_version.created_at|date:"d. M Y" }}</p>
                     </div>
                     <div class="basis-1/3 flex flex-col justify-around align-center font-bold">
                         {% if offer_version.user_vote %}

--- a/integreat_compass/cms/templates/offers/my_offers_list.html
+++ b/integreat_compass/cms/templates/offers/my_offers_list.html
@@ -31,7 +31,7 @@
                                 <span class="bg-red-500 text-white rounded-full py-1 px-2 mr-1">{{ tag }}</span>
                             {% endfor %}
                         </div>
-                        <p class="text-gray-700">{% translate "Created at:" %} {{ offer.latest_version.offer_version_date }}</p>
+                        <p class="text-gray-700">{% translate "Created at:" %} {{ offer.latest_version.created_at|date:"d. M Y" }}</p>
                     </div>
                     <div class="basis-1/4 flex flex-col shrink-0 justify-start gap-4 py-6 pr-6">
                         {% if offer.latest_version.state is True %}

--- a/integreat_compass/locale/de/LC_MESSAGES/django.po
+++ b/integreat_compass/locale/de/LC_MESSAGES/django.po
@@ -543,6 +543,11 @@ msgstr "Kategorien"
 msgid "Offers"
 msgstr "Maßnahmen"
 
+#: cms/templates/index.html cms/templates/interactions/vote_form.html
+#: cms/templates/offers/my_offers_list.html
+msgid "Created at:"
+msgstr "Erstellt am:"
+
 #: cms/templates/index.html
 msgid "No offers could be found"
 msgstr "Es konnten keine Maßnahmen gefunden werden"
@@ -551,10 +556,6 @@ msgstr "Es konnten keine Maßnahmen gefunden werden"
 #: cms/templates/overlay/offer-detail-overlay.html
 msgid "Short description"
 msgstr "Kurzbeschreibung"
-
-#: cms/templates/interactions/vote_form.html
-msgid "created at"
-msgstr "Erstellt am:"
 
 #: cms/templates/interactions/vote_form.html
 msgid "You have approved this application"
@@ -599,10 +600,6 @@ msgstr "Titelbild auswählen"
 #: cms/templates/offers/my_offers_list.html
 msgid "My offers"
 msgstr "Meine Maßnahmen"
-
-#: cms/templates/offers/my_offers_list.html
-msgid "Created at:"
-msgstr "Erstellt am:"
 
 #: cms/templates/offers/my_offers_list.html
 msgid "Your offer application has been approved."
@@ -759,6 +756,9 @@ msgstr "Deutsch"
 #: core/settings.py
 msgid "English"
 msgstr "Englisch"
+
+#~ msgid "created at"
+#~ msgstr "Erstellt am:"
 
 #~ msgid "Dashboard"
 #~ msgstr "Dashboard"


### PR DESCRIPTION
### Short description
This PR fixes the display of dates for the two views: "all offers" and "my offers".

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change offer_version_date to created_at, since this is the new database field
- Change format of dates to "d. M Y" to match the format modeled in the mockups


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I think none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #92 
