### PR TITLE
Fix fallback title image not being shown

### DIFF
--- a/integreat_compass/cms/templates/index.html
+++ b/integreat_compass/cms/templates/index.html
@@ -98,13 +98,11 @@
                             <div id="offer-{{ offer.id }}"
                                  class="single-offer bg-white flex shadow-lg hover:shadow-xl rounded-2xl hover:cursor-pointer">
                                 <div class="w-4/12 flex items-center">
-                                    {% if offer.public_version.title_image %}
-                                        <img class="rounded-2xl"
-                                             src="{{ offer.public_version.title_image.url }}"
-                                             width="100%"
-                                             height="100%"
-                                             alt="">
-                                    {% endif %}
+                                    <img class="rounded-2xl"
+                                         src="{{ offer.public_version.title_image_url }}"
+                                         width="100%"
+                                         height="100%"
+                                         alt="">
                                 </div>
                                 <div class="w-8/12 py-2 px-4">
                                     <h3 class="font-bold">{{ offer.public_version.title }}</h3>

--- a/integreat_compass/cms/templates/overlay/offer-detail-overlay.html
+++ b/integreat_compass/cms/templates/overlay/offer-detail-overlay.html
@@ -18,13 +18,11 @@
                 <div class="md:flex mb-4 xl:mb-6">
                     <div class="xl:flex mr-12">
                         <div class="mr-8">
-                            {% if offer.public_version.title_image %}
-                                <img class="rounded-2xl"
-                                     src="{{ offer.public_version.title_image.url }}"
-                                     width="100%"
-                                     height="100%"
-                                     alt="">
-                            {% endif %}
+                            <img class="rounded-2xl"
+                                 src="{{ offer.public_version.title_image_url }}"
+                                 width="100%"
+                                 height="100%"
+                                 alt="">
                         </div>
                         <div class="mt-4 xl:mt-0 w-full text-gray-500">
                             <h3 class="text-xl font-semibold">{% translate "Short description" %}</h3>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
If an offer used the default fallback image, it was not shown in the list view or detail view.

### Proposed changes
<!-- Describe this PR in more detail. -->

- use the `title_image_url` property introduced in #71 instead of `title_image.url`



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a
