### PR TITLE
Add details overlay to applications and add more fields

### DIFF
--- a/integreat_compass/cms/templates/index.html
+++ b/integreat_compass/cms/templates/index.html
@@ -96,7 +96,7 @@
                     {% if offers %}
                         {% for offer in offers %}
                             <div id="offer-{{ offer.id }}"
-                                 class="single-offer bg-white flex shadow-lg hover:shadow-xl rounded-2xl hover:cursor-pointer">
+                                 class="open-details bg-white flex shadow-lg hover:shadow-xl rounded-2xl hover:cursor-pointer">
                                 <div class="w-4/12 flex items-center">
                                     <img class="rounded-2xl object-cover h-[300px]"
                                          src="{{ offer.public_version.title_image_url }}"

--- a/integreat_compass/cms/templates/index.html
+++ b/integreat_compass/cms/templates/index.html
@@ -115,7 +115,7 @@
                                     <p class="text-gray-400">{% translate "Created at:" %} {{ offer.public_version.created_at|date:"d. M Y" }}</p>
                                 </div>
                             </div>
-                            {% include "overlay/offer-detail-overlay.html" %}
+                            {% include "overlay/offer-detail-overlay.html" with public_version=True offer=offer offer_version=offer.public_version %}
                         {% endfor %}
                     {% else %}
                         {% translate "No offers could be found" %}

--- a/integreat_compass/cms/templates/interactions/decline_list.html
+++ b/integreat_compass/cms/templates/interactions/decline_list.html
@@ -8,21 +8,30 @@
 {% endblock title %}
 {% block content %}
     {% include "includes/dashboard_navbar.html" %}
-    {% for offer in declined_offers %}
-        <div class="flex flex-row border-2 border-gray-200 bg-white rounded-lg shadow-md shadow-inner p-6 mb-8">
-            <div class="basis-2/3 pr-8">
-                <p class="text-xl font-bold">{{ offer.title }}</p>
-                <p>{{ offer.offer.organization.name }}</p>
-                <p class="text-xl text-gray-700 font-semibold pt-4">{% translate "Short description" %}</p>
-                <p class="text-gray-600">{{ offer.description|truncatechars:500 }}</p>
-                <div class=" my-4">
-                    {% for tag in offer.offer.tags.all %}
-                        <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
-                    {% endfor %}
+    {% for offer_version in declined_offers %}
+        <div class="flex flex-row border-2 border-gray-200 bg-white rounded-lg shadow-md shadow-inner mb-8">
+            <div class="basis-2/3 pr-8 flex">
+                <div class="basis-1/8 shrink-0 mr-8">
+                    <img class="object-cover h-[300px] rounded-l-lg"
+                         src="{{ offer_version.title_image_url }}"
+                         alt="Title image of this offer"
+                         width="300"
+                         height="300">
                 </div>
-                <p class="text-gray-700">{% translate "Created at:" %} {{ offer.created_at|date:"d. M Y" }}</p>
+                <div class="py-4">
+                    <p class="text-xl font-bold">{{ offer_version.title }}</p>
+                    <p>{{ offer_version.offer.organization.name }}</p>
+                    <p class="text-xl text-gray-700 font-semibold pt-4">{% translate "Short description" %}</p>
+                    <p class="text-gray-600">{{ offer_version.description|truncatechars:200 }}</p>
+                    <div class=" my-4">
+                        {% for tag in offer_version.offer.tags.all %}
+                            <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                    <p class="text-gray-700">{% translate "Created at:" %} {{ offer_version.created_at|date:"d. M Y" }}</p>
+                </div>
             </div>
-            <div class="basis-1/3 flex items-center"></div>
+            <div class="basis-1/3 flex items-center pr-6"></div>
         </div>
     {% empty %}
         {% translate "No offers have been declined by the board." %}

--- a/integreat_compass/cms/templates/interactions/report_list.html
+++ b/integreat_compass/cms/templates/interactions/report_list.html
@@ -9,20 +9,29 @@
 {% block content %}
     {% include "includes/dashboard_navbar.html" %}
     {% for report in reports %}
-        <div class="flex flex-row border-2 border-gray-200 bg-white rounded-lg shadow-md shadow-inner p-6 mb-8">
-            <div class="basis-2/3 pr-8">
-                <p class="text-xl font-bold">{{ report.offer_version.title }}</p>
-                <p>{{ report.offer_version.offer.organization.org_name }}</p>
-                <p class="text-xl text-gray-700 font-semibold pt-4">{% translate "Short description" %}</p>
-                <p class="text-gray-600">{{ report.offer_version.description|truncatechars:500 }}</p>
-                <div class=" my-4">
-                    {% for tag in report.offer_version.offer.tags.all %}
-                        <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
-                    {% endfor %}
+        <div class="flex flex-row border-2 border-gray-200 bg-white rounded-lg shadow-md shadow-inner mb-8">
+            <div class="basis-2/3 pr-8 flex">
+                <div class="basis-1/8 shrink-0 mr-8">
+                    <img class="object-cover h-[300px] rounded-l-lg"
+                         src="{{ report.offer_version.title_image_url }}"
+                         alt="Title image of this offer"
+                         width="300"
+                         height="300">
                 </div>
-                <p class="text-gray-700">{% translate "Created at:" %} {{ report.offer_version.created_at|date:"d. M Y" }}</p>
+                <div class="py-4">
+                    <p class="text-xl font-bold">{{ report.offer_version.title }}</p>
+                    <p>{{ report.offer_version.offer.organization.org_name }}</p>
+                    <p class="text-xl text-gray-700 font-semibold pt-4">{% translate "Short description" %}</p>
+                    <p class="text-gray-600">{{ report.offer_version.description|truncatechars:200 }}</p>
+                    <div class=" my-4">
+                        {% for tag in report.offer_version.offer.tags.all %}
+                            <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
+                        {% endfor %}
+                    </div>
+                    <p class="text-gray-700">{% translate "Created at:" %} {{ report.offer_version.created_at|date:"d. M Y" }}</p>
+                </div>
             </div>
-            <div class="basis-1/3 flex flex-col justify-around align-center">
+            <div class="basis-1/3 flex flex-col justify-around align-center pr-6">
                 <div>
                     <h3 class="font-semibold text-gray-700">{% translate "Reason" %}</h3>
                     <p class="text-gray-600">{{ report.comment }}</p>
@@ -32,13 +41,16 @@
                     <input type="hidden"
                            name="offer_version_id"
                            value="{{ report.offer_version.id }}">
-                    <div class="grid lg:grid-cols-3 grid-cols-1 xl:gap-8 gap-2 text-white ">
-                        <button class="bg-blue-500 hover:bg-blue-700 rounded-full" type="button">{% translate "Details" %}</button>
+                    <div class="grid lg:grid-cols-3 grid-cols-1 xl:gap-8 gap-2 text-white font-bold">
+                        <button id="offer-{{ report.offer_version.offer.id }}"
+                                class="open-details bg-blue-500 hover:bg-blue-700 rounded-full"
+                                type="button">{% translate "Details" %}</button>
                         <button class="bg-red-500 hover:bg-red-700 rounded-full"
                                 type="submit"
                                 name="move-to-declined"
                                 value="True">{% translate "Reject version" %}</button>
                     </div>
+                    {% include "overlay/offer-detail-overlay.html" with offer=report.offer_version.offer offer_version=report.offer_version public_version=False %}
                 </form>
             </div>
         </div>

--- a/integreat_compass/cms/templates/interactions/vote_form.html
+++ b/integreat_compass/cms/templates/interactions/vote_form.html
@@ -51,7 +51,9 @@
                         </div>
                         <input type="hidden" name="offer_version_id" value="{{ offer_version.id }}">
                         <div class="grid lg:grid-cols-3 grid-cols-1 xl:gap-8 gap-2 text-white ">
-                            <button class="bg-blue-500 hover:bg-blue-700 rounded-full" type="button">{% translate "Details" %}</button>
+                            <button id="offer-{{ offer_version.id }}"
+                                    class="single-offer bg-blue-500 hover:bg-blue-700 rounded-full"
+                                    type="button">{% translate "Details" %}</button>
                             <button class="bg-green-500 hover:bg-green-700 rounded-full"
                                     type="submit"
                                     name="approval"
@@ -64,6 +66,7 @@
                     </div>
                 </div>
             </form>
+            {% include "overlay/offer-detail-overlay.html" with offer=offer_version.offer offer_version=offer_version public_version=False %}
         {% endfor %}
     </div>
 {% endblock content %}

--- a/integreat_compass/cms/templates/interactions/vote_form.html
+++ b/integreat_compass/cms/templates/interactions/vote_form.html
@@ -12,20 +12,29 @@
         {% for offer_version in pending_offer_versions %}
             <form action="{% url 'cms:protected:votes' %}" method="post">
                 {% csrf_token %}
-                <div class="flex flex-row border-2 border-gray-200 bg-white rounded-lg shadow-md shadow-inner p-6 mb-8">
-                    <div class="basis-2/3 pr-8">
-                        <p class="text-xl font-bold">{{ offer_version.title }}</p>
-                        <p>{{ offer_version.offer.organization.org_name }}</p>
-                        <p class="text-xl text-gray-700 font-semibold pt-4">{% translate "Short description" %}</p>
-                        <p class="text-gray-600">{{ offer_version.description|truncatechars:500 }}</p>
-                        <div class=" my-4">
-                            {% for tag in offer_version.offer.tags.all %}
-                                <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
-                            {% endfor %}
+                <div class="flex flex-row border-2 border-gray-200 bg-white rounded-lg shadow-md shadow-inner mb-8">
+                    <div class="basis-2/3 pr-8 flex">
+                        <div class="basis-1/8 shrink-0 mr-8">
+                            <img class="object-cover h-[300px] rounded-l-lg"
+                                 src="{{ offer_version.title_image_url }}"
+                                 alt="Title image of this offer"
+                                 width="300"
+                                 height="300">
                         </div>
-                        <p class="text-gray-700">{% translate "Created at:" %} {{ offer_version.created_at|date:"d. M Y" }}</p>
+                        <div class="py-4">
+                            <p class="text-xl font-bold">{{ offer_version.title }}</p>
+                            <p>{{ offer_version.offer.organization.org_name }}</p>
+                            <p class="text-xl text-gray-700 font-semibold pt-4">{% translate "Short description" %}</p>
+                            <p class="text-gray-600">{{ offer_version.description|truncatechars:200 }}</p>
+                            <div class="my-4">
+                                {% for tag in offer_version.offer.tags.all %}
+                                    <span class="bg-red-500 text-white rounded-full py-1 px-2">{{ tag }}</span>
+                                {% endfor %}
+                            </div>
+                            <p class="text-gray-700">{% translate "Created at:" %} {{ offer_version.created_at|date:"d. M Y" }}</p>
+                        </div>
                     </div>
-                    <div class="basis-1/3 flex flex-col justify-around align-center font-bold">
+                    <div class="basis-1/3 flex flex-col pr-6 justify-around align-center font-bold">
                         {% if offer_version.user_vote %}
                             {% if offer_version.user_vote.approval %}
                                 <p class="text-green-500">{% translate "You have approved this application" %}</p>
@@ -51,8 +60,8 @@
                         </div>
                         <input type="hidden" name="offer_version_id" value="{{ offer_version.id }}">
                         <div class="grid lg:grid-cols-3 grid-cols-1 xl:gap-8 gap-2 text-white ">
-                            <button id="offer-{{ offer_version.id }}"
-                                    class="single-offer bg-blue-500 hover:bg-blue-700 rounded-full"
+                            <button id="offer-{{ offer_version.offer.id }}"
+                                    class="open-details bg-blue-500 hover:bg-blue-700 rounded-full"
                                     type="button">{% translate "Details" %}</button>
                             <button class="bg-green-500 hover:bg-green-700 rounded-full"
                                     type="submit"

--- a/integreat_compass/cms/templates/overlay/offer-detail-overlay.html
+++ b/integreat_compass/cms/templates/overlay/offer-detail-overlay.html
@@ -11,7 +11,7 @@
                 <div class="flex items-center">
                     {% if public_version %}
                         <a href="{% url 'cms:public:report_offer' pk=offer.id %}"
-                           class="flex items-center my-0 mr-8">
+                           class="text-gray-600 flex items-center my-0 mr-8">
                             <i class="mr-2" icon-name="alert-triangle"></i>
                             {% translate "Report" %}
                         </a>
@@ -54,6 +54,30 @@
                             <div>
                                 <h3 class="text-xl mt-4 font-semibold">{% translate "Address" %}</h3>
                                 <p>{{ offer.location.address }}</p>
+                            </div>
+                            <div>
+                                <h3 class="text-xl mt-4 font-semibold">{% translate "Organization" %}</h3>
+                                <a href="{{ offer.organization.web_address }}">{{ offer.organization.web_address }}</a>
+                            </div>
+                            <div>
+                                <h3 class="text-xl mt-4 font-semibold">{% translate "More details" %}</h3>
+                                <p>
+                                    {% translate "Free?" %}
+                                    {% if offer_version.is_free %}
+                                        {% translate "Yes" %}
+                                    {% else %}
+                                        {% translate "No" %}
+                                    {% endif %}
+                                </p>
+                                <p>{% translate "Language:" %} {{ offer_version.language }}</p>
+                                <p>
+                                    {% translate "Group type:" %}
+                                    {{ offer.group_type }}
+                                </p>
+                                <p>
+                                    {% translate "Mode type:" %}
+                                    {{ offer.mode_type }}
+                                </p>
                             </div>
                         </div>
                     </div>

--- a/integreat_compass/cms/templates/overlay/offer-detail-overlay.html
+++ b/integreat_compass/cms/templates/overlay/offer-detail-overlay.html
@@ -5,15 +5,17 @@
         <div class="bg-white opacity-100 content rounded-2xl shadow-md w-full">
             <div class="flex justify-between rounded-2xl p-4">
                 <div>
-                    <h2 class="font-bold text-2xl font-default">{{ offer.public_version.title }}</h2>
+                    <h2 class="font-bold text-2xl font-default">{{ offer_version.title }}</h2>
                     <p class="text-gray-600">{{ offer.organization.name }}</p>
                 </div>
                 <div class="flex items-center">
-                    <a href="{% url 'cms:public:report_offer' pk=offer.id %}"
-                       class="flex items-center my-0 mr-8">
-                        <i class="mr-2" icon-name="alert-triangle"></i>
-                        {% translate "Report" %}
-                    </a>
+                    {% if public_version %}
+                        <a href="{% url 'cms:public:report_offer' pk=offer.id %}"
+                           class="flex items-center my-0 mr-8">
+                            <i class="mr-2" icon-name="alert-triangle"></i>
+                            {% translate "Report" %}
+                        </a>
+                    {% endif %}
                     <button type="button"
                             id="btn-close-offer-detail-layover-{{ offer.id }}"
                             class="flex ml-auto bg-red-500 hover:bg-red-600 text-white">
@@ -26,17 +28,19 @@
                     <div class="xl:flex mr-12">
                         <div class="mr-8">
                             <img class="rounded-2xl object-cover h-[300px]"
-                                 src="{{ offer.public_version.title_image_url }}"
+                                 src="{{ offer_version.title_image_url }}"
                                  width="100%"
                                  height="100%"
                                  alt="">
                         </div>
                         <div class="mt-4 xl:mt-0 w-full text-gray-500">
                             <h3 class="text-xl font-semibold">{% translate "Short description" %}</h3>
-                            <p>{{ offer.public_version.description }}</p>
-                            {% for tag in offer.tags.all %}
-                                <span class="text-white bg-primary rounded-2xl px-3 py-1 leading-8">{{ tag }}</span>
-                            {% endfor %}
+                            <p>{{ offer_version.description }}</p>
+                            <div class="mt-4">
+                                {% for tag in offer.tags.all %}
+                                    <span class="text-white bg-primary rounded-2xl px-3 py-1 leading-8">{{ tag }}</span>
+                                {% endfor %}
+                            </div>
                         </div>
                     </div>
                     <div class="mt-4 xl:mt-0">
@@ -49,41 +53,41 @@
                             </div>
                             <div>
                                 <h3 class="text-xl mt-4 font-semibold">{% translate "Address" %}</h3>
-                                {{ offer.location.address }}
+                                <p>{{ offer.location.address }}</p>
                             </div>
                         </div>
                     </div>
-                </div>
-                <div class="md:flex justify-between">
-                    <div class="w-1/2 mr-12 xl:mr-0 xl:w-1/3 text-gray-500">
-                        <!-- TODO: Ratings -->
-                    </div>
-                    {% if offer.public_version.documents.first %}
-                        <div class="w-1/2">
-                            <div class="mb-4">
-                                <h3 class="inline-block p-4 xl:pt-0 border-b-2 rounded-t-lg">{% translate "Documents" %}</h3>
-                                <ul>
-                                    {% for document in offer.public_version.documents.all %}
-                                        <li class="flex mt-4">
-                                            <div class="flex items-center">
-                                                {% if document.file_type == "application/pdf" %}
-                                                    <i icon-name="file-text"></i>
-                                                {% else %}
-                                                    <i icon-name="file-image"></i>
-                                                {% endif %}
-                                            </div>
-                                            <div class="ml-4">
-                                                <a href="{{ document.file.url }}" target="_blank" class="font-bold">{{ document.name }}</a>
-                                                <p>{{ offer.public_version.created_at }}</p>
-                                            </div>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            </div>
-                        </div>
-                    {% endif %}
                 </div>
             </div>
+        </div>
+        <div class="md:flex justify-between">
+            <div class="w-1/2 mr-12 xl:mr-0 xl:w-1/3 text-gray-500">
+                <!-- TODO: Ratings -->
+            </div>
+            {% if offer_version.documents.first %}
+                <div class="w-1/2">
+                    <div class="mb-4">
+                        <h3 class="inline-block p-4 xl:pt-0 border-b-2 rounded-t-lg">{% translate "Documents" %}</h3>
+                        <ul>
+                            {% for document in offer_version.documents.all %}
+                                <li class="flex mt-4">
+                                    <div class="flex items-center">
+                                        {% if document.file_type == "application/pdf" %}
+                                            <i icon-name="file-text"></i>
+                                        {% else %}
+                                            <i icon-name="file-image"></i>
+                                        {% endif %}
+                                    </div>
+                                    <div class="ml-4">
+                                        <a href="{{ document.file.url }}" target="_blank" class="font-bold">{{ document.name }}</a>
+                                        <p>{{ offer_version.created_at }}</p>
+                                    </div>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/integreat_compass/locale/de/LC_MESSAGES/django.po
+++ b/integreat_compass/locale/de/LC_MESSAGES/django.po
@@ -123,10 +123,12 @@ msgid "A valid address is required."
 msgstr "Eine gültige Adresse ist erforderlich."
 
 #: cms/forms/offers/offer_version_form.py
+#: cms/templates/overlay/offer-detail-overlay.html
 msgid "Yes"
 msgstr "Ja"
 
 #: cms/forms/offers/offer_version_form.py
+#: cms/templates/overlay/offer-detail-overlay.html
 msgid "No"
 msgstr "Nein"
 
@@ -774,6 +776,30 @@ msgid "Address"
 msgstr "Adresse"
 
 #: cms/templates/overlay/offer-detail-overlay.html
+msgid "Organization"
+msgstr "Organisation"
+
+#: cms/templates/overlay/offer-detail-overlay.html
+msgid "More details"
+msgstr "Weitere Details"
+
+#: cms/templates/overlay/offer-detail-overlay.html
+msgid "Free?"
+msgstr "Kostenlos?"
+
+#: cms/templates/overlay/offer-detail-overlay.html
+msgid "Language:"
+msgstr "Sprache:"
+
+#: cms/templates/overlay/offer-detail-overlay.html
+msgid "Group type:"
+msgstr "Gruppentyp:"
+
+#: cms/templates/overlay/offer-detail-overlay.html
+msgid "Mode type:"
+msgstr "Modustype:"
+
+#: cms/templates/overlay/offer-detail-overlay.html
 msgid "Documents"
 msgstr "Dokumente"
 
@@ -893,6 +919,21 @@ msgstr "Deutsch"
 #: core/settings.py
 msgid "English"
 msgstr "Englisch"
+
+#~ msgid "Private"
+#~ msgstr "privat"
+
+#~ msgid "Group"
+#~ msgstr "Gruppe"
+
+#~ msgid "Online"
+#~ msgstr "online"
+
+#~ msgid "Hybrid"
+#~ msgstr "hybrid"
+
+#~ msgid "In person"
+#~ msgstr "vor Ort"
 
 #~ msgid "Created at"
 #~ msgstr "Erstellt am:"

--- a/integreat_compass/static/src/js/offer-details.ts
+++ b/integreat_compass/static/src/js/offer-details.ts
@@ -16,6 +16,14 @@ export const handleOfferDetails = () => {
                 }
             });
         }
+        if (offerDetailLayover) {
+            // Close window by clicking on backdrop.
+            offerDetailLayover.addEventListener("click", (e) => {
+                if (e.target === offerDetailLayover) {
+                    offerDetailLayover.classList.toggle("hidden");
+                }
+            });
+        }
     }
 };
 

--- a/integreat_compass/static/src/js/offer-details.ts
+++ b/integreat_compass/static/src/js/offer-details.ts
@@ -1,5 +1,5 @@
 export const handleOfferDetails = () => {
-    const allOffers = document.getElementsByClassName("single-offer");
+    const allOffers = document.getElementsByClassName("open-details");
     for (const offer of allOffers) {
         const id = offer.id.replace("offer-", "");
         const offerDetailLayover = document.getElementById(`offer-detail-layover-${id}`);


### PR DESCRIPTION
### Short description
This PR adds the detail overlay for offers to the application section. For the cases where we would access the version of an offer I created another variable called offer_version, which for "All Offers" is offer.public_version and for "Applications" is offer.latest_version. With that it was possible to stay DRY :)

### Proposed changes
<!-- Describe this PR in more detail. -->

- Extend the detail offer view to the application process 
- Make it possible to close popup when clicking on backdrop
- Rename trigger to open details offer from "single-offer" to "open-details" to make it clearer what happens when you add this class to an element
- Add image to view list


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I think none
- The last part where I see some room for improvement would be the naming of the variables in the offer-details.ts. In some cases I still use layover but we agreed to use overlay instead. If wanted, I can rename them and add it to this PR


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #87,  #107
