### PR TITLE
Fix reset button for map filter & adjust zoom on map

### DIFF
--- a/integreat_compass/cms/templates/index.html
+++ b/integreat_compass/cms/templates/index.html
@@ -121,6 +121,7 @@
                                                class="filter-element hidden peer"
                                                type="radio"
                                                name="radius"
+                                               {% if distance == 5 %}checked{% endif %}
                                                {% if distance|slugify == filtered_radius %}checked{% endif %}
                                                value="{{ distance }}">
                                         <label for="distance-{{ distance }}"

--- a/integreat_compass/static/src/js/map.ts
+++ b/integreat_compass/static/src/js/map.ts
@@ -165,7 +165,6 @@ const initializeFilterMap = () => {
     initializeMap(container, searchBar, radiusToZoom(radius));
 
     reset.addEventListener("click", () => {
-        console.log("here");
         params.delete("radius");
         (document.querySelector('input[name="radius"]:checked') as HTMLInputElement).checked = false;
         updateField("lat", "");


### PR DESCRIPTION
### Short description
This PR fixes the reset button for map filter, if there was no given distance. Also it adjusts the zoom on the map if there there is no radius set.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Set default radius to 1. With the already existing implementation this already fixes both issues
- Add check if the reset-checkbox exists to avoid JS error message and failure of subsequent code


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Admittedly this is probably just a quick & dirty solution. If you have ideas for improvement, please let me know
- The current implementation doesn't activate the filter. In my experience this is the common way to use filters like this. Optionally we could also activate the filter with the default value of radius=1, which probably would result in no results most of the time or set the default value to radius=5 including a visual indication


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #129, 
Fixes: #130
