### PR TITLE
Fix overlay in report details not opening

### DIFF
--- a/integreat_compass/cms/templates/index.html
+++ b/integreat_compass/cms/templates/index.html
@@ -173,7 +173,7 @@
                                     <p class="text-gray-700">{% translate "Created at:" %} {{ offer.public_version.created_at|date:"d. M Y" }}</p>
                                 </div>
                             </div>
-                            {% include "overlay/offer_detail_overlay.html" with public_version=True offer=offer offer_version=offer.public_version %}
+                            {% include "overlay/offer_detail_overlay.html" with public_version=True id=offer.id offer=offer offer_version=offer.public_version %}
                         {% endfor %}
                     {% else %}
                         {% translate "No offers could be found" %}

--- a/integreat_compass/cms/templates/interactions/report_list.html
+++ b/integreat_compass/cms/templates/interactions/report_list.html
@@ -30,7 +30,7 @@
                     </div>
                     <div class="flex justify-between">
                         <p class="text-gray-700">{% translate "Created at:" %} {{ report.offer_version.created_at|date:"d. M Y" }}</p>
-                        <button id="offer-{{ report.offer_version.offer.id }}"
+                        <button id="offer-{{ report.id }}"
                                 class="open-details btn btn-outline !font-normal py-3 px-4 border-2 !border-gray-600 !text-gray-600 bg-white hover:!bg-gray-600 hover:!text-white"
                                 type="button">
                             <i class="mr-2" icon-name="link"></i>{% translate "Details" %}
@@ -53,7 +53,7 @@
                             {% translate "Reject offer until provider addresses concerns" %}
                         </button>
                     </div>
-                    {% include "overlay/offer_detail_overlay.html" with offer=report.offer_version.offer offer_version=report.offer_version public_version=False %}
+                    {% include "overlay/offer_detail_overlay.html" with id=report.id offer=report.offer_version.offer offer_version=report.offer_version public_version=False %}
                 </form>
             </div>
         </div>

--- a/integreat_compass/cms/templates/interactions/vote_form.html
+++ b/integreat_compass/cms/templates/interactions/vote_form.html
@@ -33,7 +33,7 @@
                             </div>
                             <div class="flex justify-between">
                                 <p class="text-gray-700">{% translate "Created at:" %} {{ offer_version.created_at|date:"d. M Y" }}</p>
-                                <button id="offer-{{ offer_version.offer.id }}"
+                                <button id="offer-{{ offer_version.id }}"
                                         type="button"
                                         class="open-details btn btn-outline !font-normal py-3 px-4 border-2 !border-gray-600 !text-gray-600 bg-white hover:!bg-gray-600 hover:!text-white">
                                     <i icon-name="link"></i>
@@ -96,7 +96,7 @@
                 {% include "overlay/offer_application_overlay.html" %}
                 {% include "overlay/offer_application_overlay.html" with declined="True" %}
             </form>
-            {% include "overlay/offer_detail_overlay.html" with offer=offer_version.offer offer_version=offer_version public_version=False %}
+            {% include "overlay/offer_detail_overlay.html" with id=offer_version.id offer=offer_version.offer offer_version=offer_version public_version=False %}
         {% endfor %}
     </div>
 {% endblock content %}

--- a/integreat_compass/cms/templates/overlay/offer_detail_overlay.html
+++ b/integreat_compass/cms/templates/overlay/offer_detail_overlay.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<div id="offer-detail-layover-{{ offer.id }}"
+<div id="offer-detail-layover-{{ id }}"
      class="hidden mt-24 fixed items-center justify-center inset-0 bg-opacity-75 bg-gray-800 overflow-scroll z-50 cursor-pointer">
     <div class="cursor-auto justify-center w-10/12 max-h-fit px-4 z-50 m-auto my-16 text-gray-700">
         <div class="bg-white opacity-100 content rounded-sm shadow-md w-full">
@@ -16,7 +16,7 @@
                             {% translate "Report" %}
                         </a>
                     {% endif %}
-                    <i id="btn-close-offer-detail-layover-{{ offer.id }}"
+                    <i id="btn-close-offer-detail-layover-{{ id }}"
                        icon-name="x"
                        class="hover:cursor-pointer w-8"></i>
                 </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is supposed to fix the issue that the overlay in the report list is not open & closing properly. While inspecting this issue I found out that the issue stemmed from a mix-up of ids. For every offer there was one overlay linked to it. However with reports it's possible to create more than one reports for the same offer. This means that the offer id is not unique anymore and therefore we had the issues with opening and closing the (right) overlay. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change from offer id to report id as unique identifier in report list
- Change from offer id to offer_version id as unique identifier in vote form (please take some time to really think about this and if there might be some unwanted side effects with this, that I might not be thinking of).


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Not unlikely, I couldn't didn't come up with one thought. Maybe you can think of some?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #157 
