### PR TITLE
Remove relative import in wsgi.py

### DIFF
--- a/integreat_compass/core/wsgi.py
+++ b/integreat_compass/core/wsgi.py
@@ -11,7 +11,7 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-from .config import read_config_file
+from integreat_compass.core.config import read_config_file
 
 
 def application(environ, start_response):


### PR DESCRIPTION
Fixes:
```
mod_wsgi (pid=16278): Failed to exec Python script file '/opt/integreat-compass/.venv/lib/python3.13/site-packages/integreat_compass/core/wsgi.py'.
mod_wsgi (pid=16278): Exception occurred processing WSGI script '/opt/integreat-compass/.venv/lib/python3.13/site-packages/integreat_compass/core/wsgi.py'.
Traceback (most recent call last):
  File "/opt/integreat-compass/.venv/lib/python3.13/site-packages/integreat_compass/core/wsgi.py", line 14, in <module>
    from .config import read_config_file
ImportError: attempted relative import with no known parent package
```